### PR TITLE
Fix PVC name

### DIFF
--- a/deploy/kustomize/v-rising.yaml
+++ b/deploy/kustomize/v-rising.yaml
@@ -63,7 +63,7 @@ spec:
       volumes:
         - name: vrising-claim0
           persistentVolumeClaim:
-            claimName: vrising-claim
+            claimName: vrising
         - name: vrising-serverhostsettings
           configMap:
             name: vrising-serverhostsettings


### PR DESCRIPTION
- Streamline dockerfile
- Dockerfile is capital
- Add k8s deployment
- Add config map
- Add json for settings
- Remove default configmap
- Add server game settings config maps.
- switch to lowercase
- Add volume subpaths
- something is broken
- Remove PVC
- fix path
